### PR TITLE
Only investigate suspicious events

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -1,4 +1,5 @@
 class BuildsController < ApplicationController
+  before_action :ensure_suspicious_event, only: :create
   rescue_from(JSON::ParserError) { head(:bad_request) }
 
   def index
@@ -20,5 +21,12 @@ class BuildsController < ApplicationController
     else
       head(:bad_request)
     end
+  end
+
+  private
+
+  def ensure_suspicious_event
+    event = Policial::PullRequestEvent.new(JSON.parse(request.raw_post))
+    render(nothing: true) unless event.should_investigate?
   end
 end

--- a/spec/controllers/builds_controller_spec.rb
+++ b/spec/controllers/builds_controller_spec.rb
@@ -54,13 +54,24 @@ RSpec.describe BuildsController, type: :controller do
         post(:create, payload, format: :json)
         expect(response).to have_http_status(:created)
       end
+
+      context 'with ingnorable pull request events' do
+        before do
+          expect_any_instance_of(Policial::PullRequestEvent).to receive(
+            :should_investigate?
+          ).and_return(false)
+        end
+
+        it 'does not create a Build' do
+          expect { post(:create, payload, format: :json) }.not_to change(
+            Build, :count
+          )
+        end
+      end
     end
 
     context 'with invalid params' do
       it 'returns 400 bad request' do
-        post(:create, '{}', format: :json)
-        expect(response).to have_http_status(:bad_request)
-
         post(:create, nil, format: :json)
         expect(response).to have_http_status(:bad_request)
 


### PR DESCRIPTION
In #3 I forgot to add the `.should_investigate?` guard clause. It makes sure that we only create builds and queue investigations for `open` and `synchronize` events.
