### PR TITLE
Use Repository#github_client to run investigations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/volmer/policial.git
-  revision: 15f6afb3b5988d2e6f4dd059435ae7480c97205c
+  revision: 31398bd01516204f40e167f6dc354a00a75bbe0f
   specs:
     policial (0.0.3)
       octokit (~> 3.8)
@@ -119,7 +119,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parser (2.2.0.3)
+    parser (2.2.2.1)
       ast (>= 1.1, < 3.0)
     pg (0.18.1)
     powerpack (0.1.0)
@@ -182,7 +182,7 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    rubocop (0.29.1)
+    rubocop (0.30.0)
       astrolabe (~> 1.3)
       parser (>= 2.2.0.1, < 3.0)
       powerpack (~> 0.1)

--- a/app/jobs/investigation_job.rb
+++ b/app/jobs/investigation_job.rb
@@ -15,10 +15,11 @@ class InvestigationJob < ActiveJob::Base
   private
 
   def investigate(build)
+    detective = Policial::Detective.new(build.repository.github_client)
     event = Policial::PullRequestEvent.new(JSON.parse(build.payload))
-    investigation = Policial::Investigation.new(event.pull_request)
+    detective.brief(event)
 
-    investigation.run
+    detective.investigate
   end
 
   def accuse(build, violations)

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -16,14 +16,14 @@ class Build < ActiveRecord::Base
   # Returns a new Build with the pull request information.
   def self.from_webhook(payload)
     json = JSON.parse(payload)
-    pull_request = Policial::PullRequestEvent.new(json).pull_request
+    pull_request = Policial::PullRequestEvent.new(json).pull_request_attributes
     return if pull_request.nil?
 
     new(
-      pull_request: pull_request.number,
-      repo: pull_request.repo,
-      user: pull_request.user,
-      sha: pull_request.head_commit.sha,
+      pull_request: pull_request[:number],
+      repo: pull_request[:repo],
+      user: pull_request[:user],
+      sha: pull_request[:head_sha],
       payload: payload
     )
   end

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,3 +1,0 @@
-Octokit.configure do |c|
-  c.access_token = ENV['GITHUB_ACCESS_TOKEN']
-end

--- a/spec/jobs/investigation_job_spec.rb
+++ b/spec/jobs/investigation_job_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe InvestigationJob, type: :job do
-  let(:job) { described_class.new }
+  before { Repository.create!(name: 'org/proj') }
 
+  let(:job) { described_class.new }
   let(:build) do
     Build.create!(
       repo: 'org/proj',
@@ -12,14 +13,13 @@ RSpec.describe InvestigationJob, type: :job do
       payload: '{}'
     )
   end
-  let!(:repo) { Repository.create!(name: 'org/proj') }
 
   describe '#perform' do
     context 'the investigation does not return violations' do
       before do
         allow_any_instance_of(
-          Policial::Investigation
-        ).to receive(:run).and_return([])
+          Policial::Detective
+        ).to receive(:investigate).and_return([])
       end
 
       let!(:success_status_request) do
@@ -59,8 +59,8 @@ RSpec.describe InvestigationJob, type: :job do
         ]
 
         allow_any_instance_of(
-          Policial::Investigation
-        ).to receive(:run).and_return(violations)
+          Policial::Detective
+        ).to receive(:investigate).and_return(violations)
       end
 
       let!(:failure_status_request) do


### PR DESCRIPTION
Since now Policial supports individual Octokit clients for each detective (https://github.com/volmer/policial/pull/8), we're finally able to rely on each `Repository` access token to run investigations and to write statuses. 
